### PR TITLE
Fix #18 Gradescope output on test failure.

### DIFF
--- a/grade/runners.py
+++ b/grade/runners.py
@@ -31,7 +31,7 @@ class GradedRunner(TextTestRunner):
             # setUpClass failed.
             tests = [m for t in test for m in t.getTests()]
             results.data['tests'] = [
-                {'name': t.__qualname__, 'max_score': 0, 'score': '0', 'output': [f'{e[0]}: {e[1]}' for e in results.errors]} for
-                k, t in tests]
+                {'name': t.__qualname__, 'max_score': 0, 'score': '0', 'output': ';\n'.join([f'{e[0]}: {e[1]}' for e in results.errors])}
+                for k, t in tests]
 
         return results

--- a/test/test_runners.py
+++ b/test/test_runners.py
@@ -96,6 +96,8 @@ class TestRunner(unittest.TestCase):
         self.assertIn('visibility', results)
 
         self.assertIn('execution_time', results)
+
+        self.assertIsInstance(results['tests'][0]['output'], str)
         return
 
     def test_markdown_successful(self):
@@ -149,3 +151,5 @@ class TestClassSetupFails(unittest.TestCase):
         results = json.loads(results.json)
 
         self.assertEqual(len(results['tests']), 1)
+        self.assertIsInstance(results['tests'][0]['output'], str)
+        self.assertNotEqual(results['tests'][0]['output'], '')


### PR DESCRIPTION
This should fix #18, as it seems the problem was the output format. Since I had been saving output into a list and Gradescope wanted a string.