### PR TITLE
fix: partialcredit handles list for 'value'

### DIFF
--- a/grade/pipeline/partialcredit.py
+++ b/grade/pipeline/partialcredit.py
@@ -29,6 +29,9 @@ class PartialCredit:
     def __init__(self, pipelines: Iterator[Pipeline], value: Union[int, List[int]]):
         self.pipelines = list(pipelines)
         self.max_score = value
+        if type(value) is list:
+            self.max_score = (sum(value[:len(self.pipelines) % len(value)])
+                              + sum(value) * len(self.pipelines) // len(value))
 
         self.value = deque(value if type(value) is list else [value / len(self.pipelines)])
         self._score = 0

--- a/test/test_pipeline/test_partialcredit.py
+++ b/test/test_pipeline/test_partialcredit.py
@@ -27,3 +27,31 @@ class TestPartialCredit(unittest.TestCase):
         self.assertIn("ERROR:root:['ls'] should have exited unsuccessfully.", logs.output)
         self.assertEqual(results.score, 0)
         return
+
+    def test_value_list_credit(self):
+        pipelines = map(lambda t: Pipeline(Run(['ls'])), range(2))
+        values = [10, 1]
+        results = PartialCredit(pipelines, values)()
+        self.assertEqual(results.score, 11)
+        return
+
+    def test_score_rotation(self):
+        pipelines = map(lambda t: Pipeline(Run(['ls'])), range(5))
+        values = [100, 10, 1]
+        results = PartialCredit(pipelines, values)()
+        self.assertEqual(results.score, 221)
+        return
+
+    def test_value_list_some_fail(self):
+        pipelines = map(lambda t: Pipeline(Run([t]), AssertExitSuccess()), ['ls', 'void', 'ls', 'void'])
+        values = [10, 1]
+        results = PartialCredit(pipelines, values)()
+        self.assertEqual(results.score, 2)
+        return
+
+    def test_value_list_all_fail(self):
+        pipelines = map(lambda t: Pipeline(Run(['ls']), AssertExitFailure()), range(5))
+        values = [10, 1]
+        results = PartialCredit(pipelines, values)()
+        self.assertEqual(results.score, 0)
+        return


### PR DESCRIPTION
PartialCredit now calculates the max score if the value it received for the points is a list.

Fixes #26 