### PR TITLE
feature: testname decorator

### DIFF
--- a/grade/decorators.py
+++ b/grade/decorators.py
@@ -37,6 +37,12 @@ visibility.__doc__ = """ Simple decorator to add a __visibility__ property to a 
     - `visible` (default): test case will always be shown
     """
 
+testname = partial(static, "__testname__")
+testname.__doc__ = """ Simple decorator to add a __testname__ property to a function
+
+    Usage: @testname("Functionality Test")
+    """
+
 
 def leaderboard(name=None, order="desc"):
     """ Decorator that indicates that a test corresponds to a leaderboard column

--- a/grade/mixins.py
+++ b/grade/mixins.py
@@ -82,6 +82,19 @@ class ScoringMixin:
         self.setattr("__visibility__", visibility)
 
     @property
+    def testname(self) -> str:
+        """ Returns the name of the test.
+
+        This controls which name the students will see for a test.
+        """
+        return getattr(self.getTest(), "__testname__", None)
+
+    @testname.setter
+    def testname(self, name: str):
+        """ Sets the name of the test. """
+        self.setattr("__testname__", name)
+
+    @property
     def leaderboard(self) -> dict:
         """ Returns a dictionary with all leaderboard attributes. """
         return {"title": self.leaderboardTitle, "order": self.leaderboardOrder, "score": self.leaderboardScore}

--- a/grade/result.py
+++ b/grade/result.py
@@ -61,6 +61,11 @@ class Result(unittest.TextTestResult):
         return [m for f, m in [*self.failures, *self.errors] if f == test]
 
     def getName(self, test):
+        # If a user-defined name exists, use it.
+        name = self.getattr(test, "__testname__", None)
+        if name:
+            return name
+
         name = self.getattr(test, "__qualname__")
         # TODO: Walrus once python 3.8 is supported.
         description = test.shortDescription()

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -46,6 +46,14 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(test_visible.__visibility__, "visible")
         return
 
+    def test_testname(self):
+        @name("Test Name")
+        def test_name_exists():
+            return
+
+        self.assertEqual(test_name_exists.__testname__, "Test Name")
+        return
+
     def test_leaderboard(self):
         @leaderboard()
         def test_defaults():

--- a/test/test_mixins.py
+++ b/test/test_mixins.py
@@ -62,6 +62,18 @@ class TestScoringMixin(ScoringMixin, unittest.TestCase):
         self.assertEqual(x.test_something.__visibility__, "invisible")
         return
 
+    def test_testname(self):
+
+        class Test(ScoringMixin):
+            def test_name(self):
+                self.testname = "Name Test"
+                assert self.testname == "Name Test"
+
+        x = Test()
+        x.test_name()
+        self.assertEqual(x.test_name.__testname__, "Name Test")
+        return
+
     def test_leaderboard(self):
         """ Can we modify and recall a tests leaderboard standing? """
 


### PR DESCRIPTION
A potentially working name decorator, testname, and the corresponding attribute, __testname__, called such to not mess with the built-in __name__ attribute. (Maybe __name__ would be okay to use?)

Closes #28 once finished.

decorators.py and mixins.py have been altered, and the function in result.py that determines what name to output checks if a __testname__ attribute exists, using it if it does, and working the same as before if it does not.